### PR TITLE
Make sure that --files handles folders relative to the cwd

### DIFF
--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -257,7 +257,7 @@ class AnalyzeCommand extends Command
         }
 
         foreach ($files as $file) {
-            if (!preg_match($this->needle, $file) && !is_dir(realpath($this->directory.$file))) {
+            if (!preg_match($this->needle, $file) && !is_dir($config->getApplicationDirectory().$file)) {
                 continue;
             }
 


### PR DESCRIPTION
When passing --files=lib for example, we expect phpqa to pick up all the files on the lib folder relative to the current working directory. 
