### PR TITLE
Fix validation of 'git' and 'files' options

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php">
+
+    <testsuites>
+        <testsuite name="Integration tests">
+            <directory>tests/integration</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
          bootstrap="vendor/autoload.php">
 
     <testsuites>
+        <testsuite name="Unit tests">
+            <directory>tests/unit</directory>
+        </testsuite>
         <testsuite name="Integration tests">
             <directory>tests/integration</directory>
         </testsuite>

--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -96,19 +96,15 @@ class AnalyzeCommand extends Command
             $git = $input->getOption('git');
         }
 
-        if ($files && $git) {
+        if (!empty($files) && $git) {
             throw new \Exception('Options `files` and `git` can not used in combination.');
         }
 
-        if ($files) {
+        if (!empty($files)) {
             $files = explode(',', $files[0]);
         }
 
-        if (!$files[0]) {
-            $files = [];
-        }
-
-        if (!$files && !$git) {
+        if (empty($files) && !$git) {
             throw new \Exception('You must set `files` or `git` options.');
         }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -23,6 +23,12 @@ class Application extends BaseApplication
      */
     private $config;
 
+    public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
+    {
+        parent::__construct($name, $version);
+        $this->config = new Config();
+    }
+
     /**
      * @return \JMOlivas\Phpqa\Config
      */
@@ -32,20 +38,10 @@ class Application extends BaseApplication
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function doRun(InputInterface $input, OutputInterface $output)
-    {
-        $this->config = new Config();
-
-        parent::doRun($input, $output);
-    }
-
-    /**
      * @return string
      */
     public function getApplicationDirectory()
     {
-        return __DIR__.'/../../';
+        return __DIR__ . '/../../';
     }
 }

--- a/src/Input/FilesOption.php
+++ b/src/Input/FilesOption.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace JMOlivas\Phpqa\Input;
+
+class FilesOption
+{
+    /** @var array */
+    private $files;
+
+    /**
+     * @param array $files
+     */
+    public function __construct(array $files)
+    {
+        $this->files = $files;
+    }
+
+    /**
+     * Returns true if this option is provided but has no values
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return count($this->files) === 1 && $this->files[0] === null;
+    }
+
+    /**
+     * Returns true if this option is not provided
+     *
+     * @return bool
+     */
+    public function isAbsent()
+    {
+        return empty($this->files);
+    }
+
+    /**
+     * Normalize the provided values as an array
+     *
+     * - If it's is empty, it returns an empty array
+     * - If it's a single value separated by commas, it returns the corresponding array
+     * - Otherwise returns the value as is.
+     *
+     * @return array
+     */
+    public function normalize()
+    {
+        if ($this->isAbsent() || $this->isEmpty()) {
+            return [];
+        }
+        if (count($this->files) === 1 && strpos($this->files[0], ',') !== false) {
+            return explode(',', $this->files[0]);
+        }
+
+        return $this->files;
+    }
+}

--- a/src/Input/FilesOption.php
+++ b/src/Input/FilesOption.php
@@ -38,8 +38,8 @@ class FilesOption
     /**
      * Normalize the provided values as an array
      *
-     * - If it's is empty, it returns an empty array
-     * - If it's a single value separated by commas, it returns the corresponding array
+     * - If it's either empty or absent, it returns an empty array
+     * - If it's a single value separated by commas, it converts it to array
      * - Otherwise returns the value as is.
      *
      * @return array

--- a/tests/integration/Command/AnalyzeCommandTest.php
+++ b/tests/integration/Command/AnalyzeCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JMOlivas\Phpqa\Command;
+
+use JMOlivas\Phpqa\Console\Application;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AnalyzeCommandTest extends TestCase
+{
+    /**
+     * @test
+     * @expectedException \Exception
+     * @expectedExceptionMessage You must set `files` or `git` options.
+     */
+    function it_should_throw_exception_if_neither_files_nor_git_options_are_provided()
+    {
+        $application = new Application();
+        $command = new AnalyzeCommand();
+        $command->setApplication($application);
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+    }
+}

--- a/tests/integration/Command/AnalyzeCommandTest.php
+++ b/tests/integration/Command/AnalyzeCommandTest.php
@@ -23,4 +23,41 @@ class AnalyzeCommandTest extends TestCase
 
         $tester->execute([]);
     }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     * @expectedExceptionMessage Options `files` and `git` cannot be used in combination.
+     */
+    function it_should_throw_exception_if_both_files_and_git_options_are_provided()
+    {
+        $application = new Application();
+        $command = new AnalyzeCommand();
+        $command->setApplication($application);
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            '--files' => [null],
+            '--git' => true
+        ]);
+    }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     * @expectedExceptionMessage Options `files` needs at least one file.
+     */
+    function it_should_throw_exception_if_files_is_provided_but_it_is_empty()
+    {
+        $application = new Application();
+        $command = new AnalyzeCommand();
+        $command->setApplication($application);
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            '--files' => [null],
+        ]);
+    }
 }

--- a/tests/unit/Input/FilesOptionTest.php
+++ b/tests/unit/Input/FilesOptionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace JMOlivas\Phpqa\Input;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class FilesOptionTest extends TestCase
+{
+    /** @test */
+    function it_should_recognize_if_option_is_absent()
+    {
+        $absentInput = [];
+        $files = new FilesOption($absentInput);
+
+        $this->assertTrue($files->isAbsent());
+    }
+
+    /** @test */
+    function it_should_recognize_if_option_is_provided_but_is_empty()
+    {
+        $emptyInput = [null];
+        $files = new FilesOption($emptyInput);
+
+        $this->assertTrue($files->isEmpty());
+    }
+
+    /** @test */
+    function it_should_recognize_if_option_is_provided_correctly()
+    {
+        $validInput = ['src/'];
+        $files = new FilesOption($validInput);
+
+        $this->assertFalse($files->isAbsent());
+        $this->assertFalse($files->isEmpty());
+    }
+
+    /** @test */
+    function it_should_normalize_input_separated_by_commas()
+    {
+        // bin/phpqa analyze --files=src/,test/
+        $singleInputWithMultipleValues = ['src/,test/'];
+        $files = new FilesOption($singleInputWithMultipleValues);
+
+        $values = $files->normalize();
+
+        $this->assertCount(2, $values);
+        $this->assertEquals('src/', $values[0]);
+        $this->assertEquals('test/', $values[1]);
+    }
+
+    /** @test */
+    function it_should_return_multiple_files_input_as_is()
+    {
+        // bin/phpqa analyze --files=src/ --files=test/
+        $singleInputWithMultipleValues = ['src/','test/'];
+        $files = new FilesOption($singleInputWithMultipleValues);
+
+        $values = $files->normalize();
+
+        $this->assertCount(2, $values);
+        $this->assertEquals('src/', $values[0]);
+        $this->assertEquals('test/', $values[1]);
+    }
+
+    /** @test */
+    function it_should_return_empty_array_if_input_is_absent()
+    {
+        $absentInput = [];
+        $files = new FilesOption($absentInput);
+
+        $this->assertCount(0, $files->normalize());
+    }
+
+    /** @test */
+    function it_should_return_empty_array_if_input_is_empty()
+    {
+        $emptyInput = [null];
+        $files = new FilesOption($emptyInput);
+
+        $this->assertCount(0, $files->normalize());
+    }
+}


### PR DESCRIPTION
I found an issue when running the analyzer the following way:

```
$ bin/phpqa analyze
```

I got a warning `Undefined offset: 0`, due to the logic around `explode` for the `files` option, followed by the expected exception `You must set 'files' or 'git' options.`.

I moved the validation and normalizing of the `files` option to its own class with its corresponding tests.

I also added integration tests for the `AnalyzeCommand` that verify the `git` and `files` validation logic I changed.

One thing I noticed is that currently it is not possible to write tests for the command without modifying your `src` or whatever folder you pass to the test. It might be a good idea to create `Analyzer` objects and inject them to the app in order to make them testable or create a folder for testing with fixture files.
