### PR TITLE
Fixing ln -s directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ cd phpqa
 # download dependencies
 $ composer install
 # make phpqa globally accessible creating a symlink
-$ ln -s /path/to/phpqa/bin/phpqa /usr/local/bin/phpqa
+$ ln -s bin/phpqa /usr/local/bin/phpqa
 ```
 
 ## Usage


### PR DESCRIPTION
If the user is already in phpqa directory due to the previous steps, it makes sense to add the `ln -s` starting from the current directory. Easier and the user can copy and paste.
