### PR TITLE
fix dir scope when phpqa analyze --files=dir (standalone)

### DIFF
--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -277,7 +277,7 @@ class AnalyzeCommand extends Command
         }
 
         foreach ($files as $file) {
-            if (!preg_match($this->needle, $file) && !is_dir(realpath($this->directory.$file))) {
+            if (!preg_match($this->needle, $file) && !is_dir(realpath($file))) {
                 continue;
             }
 


### PR DESCRIPTION
when phpqa is called from another proyect (as standalone) with --files=dir realpath try to find on phpqa directory